### PR TITLE
feat : 민제가 명령한 내용

### DIFF
--- a/src/main/java/com/ssafy/trip/config/WebSecurityConfig.java
+++ b/src/main/java/com/ssafy/trip/config/WebSecurityConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -44,8 +43,9 @@ public class WebSecurityConfig {
                         .requestMatchers(
                                 "/", "/index", "/login", "/signup",
                                 "/css/**", "/js/**", "/images/**",
-                                "/api/auth/**", "/api/tour/**",
-                                "/path", "/pathtest","/api/routing/**", "/api/admin/**"
+                                "/api/auth/**", "/api/tour/**", "/error",
+                                "/path", "/pathtest", "/api/routing/**", "/api/admin/**",
+                                "/api/routes/public/**", "/api/routes/*/like"
                         ).permitAll()
                         .anyRequest().authenticated()
                 );

--- a/src/main/java/com/ssafy/trip/controller/MapController.java
+++ b/src/main/java/com/ssafy/trip/controller/MapController.java
@@ -1,15 +1,13 @@
 package com.ssafy.trip.controller;
 
 import com.ssafy.trip.domain.Attraction;
+import com.ssafy.trip.dto.AttractionDetailResponse;
 import com.ssafy.trip.dto.AttractionDto;
 import com.ssafy.trip.repository.AttractionRepository;
 import com.ssafy.trip.service.MapService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -33,6 +31,12 @@ public class MapController {
     ) {
         String keyword = (q == null || q.isBlank()) ? null : q.trim();
         return attractionRepository.searchAttractions(keyword, typeId);
+    }
+
+    @GetMapping("/attractions/{id}")
+    public AttractionDetailResponse getAttractionDetail(@PathVariable Long id) {
+
+        return mapService.getAttractionDetail(id);
     }
 
 }

--- a/src/main/java/com/ssafy/trip/controller/PublicRouteController.java
+++ b/src/main/java/com/ssafy/trip/controller/PublicRouteController.java
@@ -1,0 +1,46 @@
+package com.ssafy.trip.controller;
+
+import com.ssafy.trip.dto.RouteDetailResponse;
+import com.ssafy.trip.dto.RouteSummaryResponse;
+import com.ssafy.trip.service.RouteService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/routes/public")
+@RequiredArgsConstructor
+public class PublicRouteController {
+
+    private final RouteService routeService;
+
+    // 🔹 공개 루트 게시판
+    @GetMapping()
+    public ResponseEntity<Page<RouteSummaryResponse>> getPublicRoutes(
+            @RequestParam(defaultValue = "latest") String sort,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "12") int size,
+            Authentication authentication
+    ) {
+        String email = null;
+        if (authentication != null) email = authentication.getName();
+        Page<RouteSummaryResponse> result = routeService.getPublicRoutes(sort, page, size, email);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{id}")
+    public RouteDetailResponse getPublicRouteDetail(
+            @PathVariable Long id,
+            Authentication authentication
+    ) {
+        String email = null;
+        if (authentication != null) email = authentication.getName();
+        return routeService.getPublicRouteDetail(email, id);
+    }
+
+
+}

--- a/src/main/java/com/ssafy/trip/controller/RouteController.java
+++ b/src/main/java/com/ssafy/trip/controller/RouteController.java
@@ -3,18 +3,19 @@ package com.ssafy.trip.controller;
 
 import com.ssafy.trip.domain.Route;
 import com.ssafy.trip.dto.*;
-//import com.ssafy.trip.service.RouteAiService;
 import com.ssafy.trip.dto.ai.AiRouteRequest;
 import com.ssafy.trip.service.RouteAiService;
 import com.ssafy.trip.service.RouteService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/routes")
 @RequiredArgsConstructor
@@ -49,6 +50,15 @@ public class RouteController {
         return ResponseEntity.ok(route);
     }
 
+    @PutMapping("/{id}")
+    public RouteResponse updateRoute(@PathVariable Long id,
+                                     @RequestBody @Valid RouteUpdateRequest request,
+                                     Authentication authentication) {
+
+        String email = authentication.getName();
+        return routeService.updateRoute(email, id, request);
+    }
+
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteRoute(@PathVariable Long id,
                                             Authentication authentication) {
@@ -66,17 +76,6 @@ public class RouteController {
         return ResponseEntity.ok(updated);
     }
 
-    // 🔹 공개 루트 게시판
-    @GetMapping("/public")
-    public ResponseEntity<Page<RouteSummaryResponse>> getPublicRoutes(
-            @RequestParam(defaultValue = "latest") String sort,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "12") int size
-    ) {
-        Page<RouteSummaryResponse> result = routeService.getPublicRoutes(sort, page, size);
-        return ResponseEntity.ok(result);
-    }
-
     // 🔹 공개 여부 수정
     @PatchMapping("/{id}/visibility")
     public ResponseEntity<Route> updateVisibility(@PathVariable Long id,
@@ -91,15 +90,17 @@ public class RouteController {
     @PostMapping("/{id}/like")
     public ResponseEntity<RouteLikeResponse> toggleLike(@PathVariable Long id,
                                                         Authentication authentication) {
-        String email = authentication.getName();
+
+        String email = null;
+        if (authentication != null) email = authentication.getName();
         RouteLikeResponse res = routeService.toggleLike(email, id);
         return ResponseEntity.ok(res);
     }
 
     /**
      * 🔹 AI 기반 루트 생성
-     *  - body: AiRouteRequest (query, preferredRegion, totalDaysHint)
-     *  - 반환: 생성된 Route (id 포함)
+     * - body: AiRouteRequest (query, preferredRegion, totalDaysHint)
+     * - 반환: 생성된 Route (id 포함)
      */
     @PostMapping("/ai")
     public ResponseEntity<Route> createRouteByAi(

--- a/src/main/java/com/ssafy/trip/domain/Route.java
+++ b/src/main/java/com/ssafy/trip/domain/Route.java
@@ -2,6 +2,7 @@ package com.ssafy.trip.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.ssafy.trip.dto.RouteUpdateRequest;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -78,5 +79,12 @@ public class Route {
 
     public void updateVisibility(boolean isPublic) {
         this.isPublic = isPublic;
+    }
+
+    public void updateRoute(RouteUpdateRequest request) {
+        this.title = request.getTitle();
+        this.description = request.getDescription();
+        this.totalDays = request.getTotalDays();
+        this.isPublic = request.getIsPublic();
     }
 }

--- a/src/main/java/com/ssafy/trip/dto/AttractionDetailResponse.java
+++ b/src/main/java/com/ssafy/trip/dto/AttractionDetailResponse.java
@@ -1,0 +1,33 @@
+package com.ssafy.trip.dto;
+
+import com.ssafy.trip.domain.Attraction;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AttractionDetailResponse {
+
+    private String title;
+
+    private String addr1;
+    private String addr2;
+
+    private Double latitude;
+    private Double longitude;
+
+    private String imageUrl;
+    private String tel;
+
+    public static AttractionDetailResponse from(Attraction attraction) {
+        return AttractionDetailResponse.builder()
+                .title(attraction.getTitle())
+                .addr1(attraction.getAddr1())
+                .addr2(attraction.getAddr2())
+                .latitude(attraction.getLatitude())
+                .longitude(attraction.getLongitude())
+                .imageUrl(attraction.getImageUrl())
+                .tel(attraction.getTel())
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/trip/dto/DaysDto.java
+++ b/src/main/java/com/ssafy/trip/dto/DaysDto.java
@@ -1,0 +1,20 @@
+package com.ssafy.trip.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class DaysDto {
+    private int dayIndex;           // Day 1, Day 2 할 때 그 숫자
+    private List<PlansDto> plans; // 해당 날짜의 계획들
+
+    public static DaysDto from(int dayIndex, List<PlansDto> plans) {
+        return DaysDto.builder()
+                .dayIndex(dayIndex)
+                .plans(plans)
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/trip/dto/PlansDto.java
+++ b/src/main/java/com/ssafy/trip/dto/PlansDto.java
@@ -1,0 +1,19 @@
+package com.ssafy.trip.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PlansDto {
+    private Long planId;
+    private Long attractionId;
+    private String title;
+    private String addr1;
+    private Integer orderIndex;
+
+    public static PlansDto from() {
+        return PlansDto.builder()
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/trip/dto/RouteDetailResponse.java
+++ b/src/main/java/com/ssafy/trip/dto/RouteDetailResponse.java
@@ -2,45 +2,52 @@ package com.ssafy.trip.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ssafy.trip.domain.Route;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
-public class RouteSummaryResponse {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RouteDetailResponse {
 
-    private Long id;
     private String title;
     private String description;
 
     @JsonProperty("isPublic")
-    private Boolean isPublic;
-    
+    private boolean isPublic;
+
     private long likeCount;
     private Integer totalDays;
-
-    private String ownerName;        // 작성자 이름 / 닉네임
     private LocalDateTime createdAt;
+
+    private String ownerName;
+    private String ownerNickname;
 
     private boolean liked;
 
     @JsonProperty("isGuest")
     private boolean isGuest;
 
-    public static RouteSummaryResponse from(Route route, boolean liked, boolean isGuest) {
-        return RouteSummaryResponse.builder()
-                .id(route.getId())
+    private List<DaysDto> days;
+
+    public static RouteDetailResponse from(Route route, boolean liked, boolean isGuest
+            , List<DaysDto> days) {
+        return RouteDetailResponse.builder()
                 .title(route.getTitle())
                 .description(route.getDescription())
                 .isPublic(route.getIsPublic())
                 .likeCount(route.getLikeCount())
                 .totalDays(route.getTotalDays())
-                .ownerName(route.getMember().getName())  // Member에 맞게 수정
                 .createdAt(route.getCreatedAt())
+                .ownerName(route.getMember().getName())  // Member에 맞게 수정
+                .ownerNickname(route.getMember().getNickname())
                 .liked(liked)
                 .isGuest(isGuest)
+                .days(days)
                 .build();
     }
+
 }

--- a/src/main/java/com/ssafy/trip/dto/RouteResponse.java
+++ b/src/main/java/com/ssafy/trip/dto/RouteResponse.java
@@ -2,45 +2,37 @@ package com.ssafy.trip.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ssafy.trip.domain.Route;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
-public class RouteSummaryResponse {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RouteResponse {
 
     private Long id;
     private String title;
     private String description;
+    private Integer totalDays;
 
     @JsonProperty("isPublic")
     private Boolean isPublic;
-    
     private long likeCount;
-    private Integer totalDays;
-
-    private String ownerName;        // 작성자 이름 / 닉네임
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
-    private boolean liked;
-
-    @JsonProperty("isGuest")
-    private boolean isGuest;
-
-    public static RouteSummaryResponse from(Route route, boolean liked, boolean isGuest) {
-        return RouteSummaryResponse.builder()
+    public static RouteResponse from(Route route) {
+        return RouteResponse.builder()
                 .id(route.getId())
                 .title(route.getTitle())
                 .description(route.getDescription())
+                .totalDays(route.getTotalDays())
                 .isPublic(route.getIsPublic())
                 .likeCount(route.getLikeCount())
-                .totalDays(route.getTotalDays())
-                .ownerName(route.getMember().getName())  // Member에 맞게 수정
                 .createdAt(route.getCreatedAt())
-                .liked(liked)
-                .isGuest(isGuest)
+                .updatedAt(route.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/trip/dto/RouteUpdateRequest.java
+++ b/src/main/java/com/ssafy/trip/dto/RouteUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.ssafy.trip.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RouteUpdateRequest {
+
+    @NotNull
+    private String title;
+
+    private String description;
+
+    @Min(value = 1)
+    private Integer totalDays;
+
+    @NotNull
+    private Boolean isPublic;
+
+}

--- a/src/main/java/com/ssafy/trip/service/MapService.java
+++ b/src/main/java/com/ssafy/trip/service/MapService.java
@@ -1,19 +1,13 @@
 package com.ssafy.trip.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.trip.dto.AttractionDetailResponse;
 import com.ssafy.trip.dto.AttractionDto;
 import com.ssafy.trip.repository.AttractionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 //@Service
 //public class MapService {
@@ -93,5 +87,12 @@ public class MapService {
                 .stream()
                 .map(AttractionDto::from)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public AttractionDetailResponse getAttractionDetail(long id) {
+        return attractionRepository.findById(id)
+                .map(AttractionDetailResponse::from)
+                .orElseThrow(() -> new IllegalArgumentException("없는 관광지 입니다."));
     }
 }


### PR DESCRIPTION
해야할 것
------------------------------------------

댓글 목록: GET /api/routes/public/{id}/comments
댓글 작성: POST /api/routes/public/{id}/comments (body: { content: string })

댓글기능은 나중에쓰~~~~~ 아예 스키마가 없는것같아서 구조를 생각해봐야할 문제.
멤버 - 댓글 - 루트 이렇게는 일단 이어져야할듯?

댓글 스키마 구조는

id, 멤버id, 루트id, 댓글내용

이런식?

-------
민제가함
----------------------------------------
내 루트 목록: GET /api/routes/me 
- 민제가함. 정상작동 하는 것 같음.

루트 삭제: DELETE /api/routes/{id} 
- 민제가함. 정상작동 하는 것 같음.

공개 여부만 수정: PATCH /api/routes/{id}/visibility (body: { isPublic }) 
- 민제가함. 포스트맨으로 요청 날려본 결과 잘됨.
- 근데 예외가 터져도 포스트맨으로 안날라오길래 확인해보니 /error 경로도 시큐리티 예외에 추가해줘야함.
- 예외처리 같은 경우는 컨트롤러어드바이스에서 한꺼번에 처리해서 데이터 포맷 맞추기도 한다는듯?

--------
내가 작업함
----------------------------------------
1. 좋아요 토글: POST /api/routes/{id}/like 
- 응답: {
liked: true|false,
likeCount: number
}
- 민제가함 / 근데 토글이 정상작동하진 않음.
- 수정완 : RouteService toggleLike(?) 메소드 / 
- 근데 이거 동시성으로 요청 한번에 많이와도 잘 처리되나? 제미나이 질문결과 : 아님 / 락걸어야함. 
- 근데 락걸면 복잡함. 근데 락 안걸고도 가능한 방법은 없나? sql로 직접 수정하는거 아니면 답없는 것으로 추정. 
- 낙관적 락이 가장 편해보이는데 락걸기 무섭다. 어차피 아무도 안씀. 나의 자원낭비임.

----------------------------------------
2. 공개 루트 상세: GET /api/routes/public/{id}
응답: RouteDetailResponse (route 정보 + days/attractions + liked 여부)
수정사항
- PublicRouteController 추가해서 따로 작업해줌.
- WebSecurityConfig - "/api/routes/public/**", "/api/routes/*/like" 추가함.
- 로그인 안한 유저도 볼 수 있게끔 하는 의도.
- 그에따라 vue의 RouteDetailView에서 route 가 필요로 하는 데이터에 isGuest 추가 (버튼 활성화, 비활성화 목적)
- 그에따라 vue의 RouteBoardView에서도 isGuest여부로 버튼 비활성화 여부 체크함.
- 만약 다른곳에서도 좋아요 버튼이 있는 곳이면 추가로 수정해줘야할것같음.

- RouteController에서 toggleLike 수정. - 게스트는 눌러도 무반응. 
- 얼럿으로 뭐 게스트는 좋아요를 누를 수 없습니다 이렇게 알림뜨게 하는것도 나쁘지 않아보이는데 프론트는 잘 몰라서 일단 안건듬. 
- 근데 생각해보니 어차피 버튼으로 눌리는 모션도 없으니까 걍 둬도 노상관

- 좋아요 게속 파다보니까 재로그인 했을 때 퍼블릭보드에서 좋아요에 불 안들어옴
- 해결하기위해서 RouteSummaryResponse 에도 liked 받는거 가져오고, 추가로 isGuest또한 작업해줌. (퍼블릭보드에서 처음 스프링에서 가져오는 리스폰스가 RouteSummaryResponse로 추정해서)
- PublicRouteController getPublicRoutes 에도 email 체크로직 추가,
- RouteService 의 getPublicRoutes 에서도 liked 가져올 수 있게 로직 추가.

- RouteSummaryResponse, RouteDetailResponse 등 isPublic이라는 게 쓰인곳은 잭슨어쩌구 때문에 json으로 넘어갈때 is떼고 변수명 넘어간다고함. 그래서 어노테이션으로 변수명 위에 @JsonProperty("isPublic") 이런식으로 붙여서 고정해야함.
- 근데 날리고 보니 public, isPublic 둘다 날아감. - 롬복과의 충돌 때문이라고 예측함.
- 그냥 변수명 변경하는게 제일 나아보이는데 디비도 바꾸고 귀찮아보임. 걍 둘다 날려 몰라

- days를 받기위한 DaysDto, days안의 plans를 받기위한 PlansDto 생성.

-----진행중 : 어트랙션아이디를 연결을 못하는 중.

----------------------------------------
3. 관광지 상세: GET /api/map/attractions/{id}
- 성공 (포스트맨 잘 날아감. 프론트에서 요구하는 데이터 잘 날림.)
- json response 위한 AttractionDetailResponse 생성
- MapController 에 getAttractionDetail 메서드 추가
- MapService 에 getAttractionDetail 메서드 추가

----------------------------------------
4. 루트 수정: PUT /api/routes/{id} (body: { title, description, totalDays, isPublic })
- 완료
- RouteController 에 updateRoute 메서드 추가
- RouteUpdateRequest 추가
- RouteService 에 updateRoute 메서드 추가
- Route에 updateRoute 메서드 로직 추가
- updateVisibility 메서드 참고하면서 생각한건데, isPublic이 null로 온다면 예외처리 해줘야하지않나? 요청을 수행하지 않은건데 아니면 request 같은데서 @NotNull 같은 validation 설정을 해준다거나...음음 잘 모름.
- RouteUpdateRequest에는 valid 적용함
- jpa의 lazy어쩌구 때문에 루트자체가 바로 응답으로 안돼서 RouteResponse 생성.
- 그래도 여전히 Route안의 Member가 프록시객체라 말썽. 프론트까보니까 member 필요없음. response는 이렇게 뭉탱이로 객체를 보내는 경우는 거의 없다고함. 따라서 필요한 값들만 보내는 RouteResponse로 구조변경.

----------------------------------------
종합 궁금증 및 메모장

- 근데 매 컨트롤러마다 Authentication 체크하는거 좀 별론거같은데 인터셉터 쓰는것도 나쁘지않나? 뭐 그래봤자 두줄뿐이긴하네. 굳이인가?

- 일자별로는 어떻게 루트를 추가하지? 1일차에만 추가되기만함.

- 루트에서 관광지별 삭제 or 수정 하는 기능은 없어보임.

- 나는 일단 동시성은 거의 고려하지 않은 코드로 만듬. factos) 그딴거 고려할때가 아니긴함.

- httpstatuc code는 신경써야하는가? 응답시 create 이런거 코드 따로 보내야하나?
